### PR TITLE
Feat: Add javascript support 🚀

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 This is the simple scaffolding extension for react in modular way.
 
 # Uses
-This extension simply will create scaffold for react feature in modular way (with typescript only for now)
+
+This extension simply will create scaffold for react feature in modular way. By default react-feature will create typescript files. For javascript files we can pass estension in react feature name as `<react-feature-name>.js`.
 
 Creates following files
+
 - context (with boilerplate code for context with hooks)
 - feature name file
 - type file
 - style file
 - route file
 
+# Download
 
-# Download 
 Currently as this is made for testing and learning purpose only we are not pushing it to marketplace. But still you can use it by downloading this file from [github]('./../react-feature-0.0.1.vsix).
 
 - run `code --install-extension react-feature-0.0.1.vsix`
@@ -22,6 +24,6 @@ Currently as this is made for testing and learning purpose only we are not pushi
   - macOS `~/.vscode/extensions`
   - Linux `~/.vscode/extensions`
 
+# Demo
 
-# Demo 
 ![Demo](./demo.gif)


### PR DESCRIPTION
This PR includes feature to support javascript files. To create javascript files we can simply pass module name as `<feature-name>.js` or `<feature-name>.ts`. By default (`<feature-name>`) react-feature will create typescript files.